### PR TITLE
Feature/truffle migration benchmark

### DIFF
--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,7 +1,17 @@
 const Migrations = artifacts.require("Migrations");
 
-module.exports = (deployer, network) => {
+const web3Helper = require("../helpers/web3");
+const { address, password } = require("../household-server-config");
+
+module.exports = async (deployer, network) => {
   if (network !== "authority" && network !== "authority_docker") {
-    deployer.deploy(Migrations);
+    if (network === "benchmark") {
+      const web3 = web3Helper.initWeb3("benchmark");
+      await web3.eth.personal.unlockAccount(address, password, null);
+      await deployer.deploy(Migrations);
+      await web3.eth.personal.unlockAccount(address, password, null);
+    } else {
+      await deployer.deploy(Migrations);
+    }
   }
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,7 +3,7 @@ const request = require("request-promise");
 
 const Utility = artifacts.require("dUtility");
 const OwnedSet = artifacts.require("OwnedSet");
-const UtilityBenchmark = artifacts.require("UtilityBenchmark");
+const dUtilityBenchmark = artifacts.require("dUtilityBenchmark");
 
 const web3Helper = require("../helpers/web3");
 const asyncUtils = require("../helpers/async-utils");
@@ -127,9 +127,10 @@ module.exports = async (deployer, network, [authority]) => {
       break;
     }
     case "benchmark": {
-      deployer.deploy(UtilityBenchmark, 1000, 50, 1000, -2700, {
-        gas: 99999999
-      });
+      const web3 = web3Helper.initWeb3("benchmark");
+      await web3.eth.personal.unlockAccount(address, password, null);
+      await deployer.deploy(dUtilityBenchmark);
+      await web3.eth.personal.unlockAccount(address, password, null);
       break;
     }
     default: {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "migrate-contracts-ganache": "truffle migrate --reset hard --network ganache",
     "migrate-contracts-authority": "truffle migrate --reset hard --network authority",
     "migrate-contracts-docker": "truffle migrate --reset hard --network authority_docker",
+    "migrate-contracts:benchmark": "truffle migrate --reset hard --network benchmark",
     "test-parity-docker": "./scripts/run_docker_parity_tests.sh",
     "test-helpers": "mocha ./test/helpers/*.js",
     "test-utility-js": "mocha ./test/utility-js/*",
@@ -50,7 +51,7 @@
     "prettier": "^1.17.0",
     "run-script-os": "^1.0.5",
     "solium": "^1.2.4",
-    "truffle": "5.0.36"
+    "truffle": "^5.1.0"
   },
   "dependencies": {
     "bn.js": "4.11.8",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -31,8 +31,10 @@ module.exports = {
     },
     benchmark: {
       host: "127.0.0.1",
-      port: 7545,
-      network_id: "*"
+      port: 8546,
+      network_id: "8995",
+      websockets: true,
+      from: "0x00Bd138aBD70e2F00903268F3Db08f2D25677C9e"
     }
   },
   compilers: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5019,10 +5019,10 @@ truffle-interface-adapter@^0.2.5:
     lodash "^4.17.13"
     web3 "1.2.1"
 
-truffle@5.0.36:
-  version "5.0.36"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.36.tgz#ca8361be8e62cc351c42867d7e25fd66a1541f96"
-  integrity sha512-lcEFJYf+HzdGsIp+YS9g5mSW1wpKlkBfqu/DHFUmbzvTPV5nxKXkKCYlwWjo20lNAOBTErFtwNpw4+EOaBJVRA==
+truffle@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.1.0.tgz#670d6791a2a97c6bf852d28a978e6635fe3c883a"
+  integrity sha512-RKij9cFhHeAb8HuP8D/llpcbe+k40fg8Q2SAeR+mkvlz9tid/opYkrWs9XN8eRQKCC0SSygrKBZLG3CMsNbXwQ==
   dependencies:
     app-module-path "^2.2.0"
     mocha "5.2.0"


### PR DESCRIPTION
Fixes the truffle migration configuration for benchmark parity setup. Steps to run:
1. Start benchmark parity node via `yarn run-benchmark-node`
2. Run migration of `dUtilityBenchmark` via `yarn migrate-contracts:benchmark`